### PR TITLE
Add "mainFields" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,15 @@ You may provide
 
 #### extensions _(string[]) (default=[".ts", ".tsx"])_
 
-An array of the extensions that will be tried during resolve. Ideally this would be the same as the extensions form the webpack config but it seems resolver plug-ins does not have access to this infomration so you need to specify it again for the plugin.
+An array of the extensions that will be tried during resolve. Ideally this would be the same as the extensions from the webpack config but it seems resolver plug-ins does not have access to this infomration so you need to specify it again for the plugin.
 
 #### baseUrl _(string) (default=undefined)_
 
 This allows you to override the `baseUrl` found in tsconfig.json. The baseUrl specifies from which directory `paths` should be resolved. So this option enabled you to resolve from anhother directory than the one where tsconfig.json is located. This can be useful if you want to use webpack with `tsc --watch` instead of a typescript loader. If this option is `undefined` then the `baseUrl` from tsconfig.json will be used.
+
+#### mainFields _(string[]) (default=["main"])_
+
+An array of the field names that should be considered when resolving packages. Ideally this would be the same as the mainFields from the webpack config but it seems resolver plug-ins does not have access to this infomration so you need to specify it again for the plugin.
 
 #### silent _(boolean) (default=false)_
 

--- a/example/src/index.ts
+++ b/example/src/index.ts
@@ -1,5 +1,16 @@
 import * as foo from "foo";
 import * as bar from "bar/file1";
 import * as myStar from "star-bar";
+import * as packagedBrowser from "browser-field-package";
+import * as packagedMain from "main-field-package";
+import * as packagedIndex from "no-main-field-package";
 
-console.log("HELLO WORLD!", foo.message, bar.message, myStar.message);
+console.log(
+  "HELLO WORLD!",
+  foo.message,
+  bar.message,
+  myStar.message,
+  packagedBrowser.message,
+  packagedMain.message,
+  packagedIndex.message
+);

--- a/example/src/mapped/star/browser-field-package/browser.ts
+++ b/example/src/mapped/star/browser-field-package/browser.ts
@@ -1,0 +1,1 @@
+export const message = "browser";

--- a/example/src/mapped/star/browser-field-package/node.ts
+++ b/example/src/mapped/star/browser-field-package/node.ts
@@ -1,0 +1,1 @@
+export const message = "node";

--- a/example/src/mapped/star/browser-field-package/package.json
+++ b/example/src/mapped/star/browser-field-package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "browser-field",
+  "main": "node.ts",
+  "browser": "browser.ts"
+}

--- a/example/src/mapped/star/main-field-package/node.ts
+++ b/example/src/mapped/star/main-field-package/node.ts
@@ -1,0 +1,1 @@
+export const message = "node";

--- a/example/src/mapped/star/main-field-package/package.json
+++ b/example/src/mapped/star/main-field-package/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "main-field",
+  "main": "node.ts"
+}

--- a/example/src/mapped/star/no-main-field-package/index.ts
+++ b/example/src/mapped/star/no-main-field-package/index.ts
@@ -1,0 +1,1 @@
+export const message = "index";

--- a/example/src/mapped/star/no-main-field-package/package.json
+++ b/example/src/mapped/star/no-main-field-package/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "no-main-field"
+}

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -27,7 +27,8 @@ module.exports = {
       new TsconfigPathsPlugin({
         configFile: "./tsconfig.json",
         logLevel: "info",
-        extensions: [".ts", ".tsx"]
+        extensions: [".ts", ".tsx"],
+        mainFields: ["browser", "main"],
         // baseUrl: "/foo"
       })
     ]

--- a/src/options.ts
+++ b/src/options.ts
@@ -9,6 +9,7 @@ export interface Options {
   readonly logInfoToStdOut: boolean;
   readonly context: string;
   readonly colors: boolean;
+  readonly mainFields: string[];
 }
 
 type ValidOptions = keyof Options;
@@ -19,7 +20,8 @@ const validOptions: ReadonlyArray<ValidOptions> = [
   "silent",
   "logLevel",
   "logInfoToStdOut",
-  "context"
+  "context",
+  "mainFields"
 ];
 
 /**
@@ -64,7 +66,8 @@ function makeOptions(rawOptions: Partial<Options>): Options {
       logLevel: "WARN",
       logInfoToStdOut: false,
       context: undefined,
-      colors: true
+      colors: true,
+      mainFields: ["main"]
     } as Options),
     ...rawOptions
   };

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -165,7 +165,8 @@ export class TsconfigPathsPlugin implements ResolverPlugin {
         : loadResult.absoluteBaseUrl;
       this.matchPath = TsconfigPaths.createMatchPathAsync(
         this.absoluteBaseUrl,
-        loadResult.paths
+        loadResult.paths,
+        options.mainFields
       );
     }
   }


### PR DESCRIPTION
This adds an option "mainFields" which allows path mapped modules to resolve to the same files as the Webpack when mapped packages include field names ("main", "browser", etc).

Sadly we seem to not be able to use the Webpack config `resolve.mainFields`, so this PR only adds it as a configuration option to the plugin directly (same situation as with option `extensions`).

Depends on PR in `tsconfig-paths`: https://github.com/dividab/tsconfig-paths/pull/45

Fixes #20 