### PR TITLE
Add readJson fallback

### DIFF
--- a/base-tsconfig.json
+++ b/base-tsconfig.json
@@ -9,7 +9,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
-    // "strictNullChecks": true
+    "noUnusedParameters": true,
+    "strictNullChecks": true
   }
 }

--- a/example/custom-fs.js
+++ b/example/custom-fs.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const webpack = require('webpack');
+
+const config = require('./webpack.config');
+
+const compiler = webpack(config);
+
+compiler.inputFileSystem = fs;
+
+compiler.run(function (error, stats) {
+  if (error) {
+    console.error(error);
+    return process.exit(1);
+  }
+
+  if (stats.compilation.errors.length) {
+    stats.compilation.errors.forEach((compilationError) => {
+      logger.log(compilationError);
+    });
+
+    return process.exit(1);
+  }
+
+  console.log('Successfully compiled');
+});

--- a/example/custom-fs.js
+++ b/example/custom-fs.js
@@ -15,7 +15,7 @@ compiler.run(function (error, stats) {
 
   if (stats.compilation.errors.length) {
     stats.compilation.errors.forEach((compilationError) => {
-      logger.log(compilationError);
+      console.error(compilationError);
     });
 
     return process.exit(1);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "compile": "tsc -p src",
     "compile:tests": "tsc -p tests",
     "compile:example": "tsc -p example",
-    "example": "yarn build && cd example && webpack",
+    "example": "yarn build && cd example && webpack && node custom-fs.js",
     "build": "rimraf lib && tsc -p src",
     "lint":
       "tslint -t msbuild './src/**/*.ts{,x}' -e './src/node_modules/**/*'",

--- a/src/options.ts
+++ b/src/options.ts
@@ -3,11 +3,11 @@ export type LogLevel = "INFO" | "WARN" | "ERROR";
 export interface Options {
   readonly configFile: string;
   readonly extensions: ReadonlyArray<string>;
-  readonly baseUrl: string;
+  readonly baseUrl: string | undefined;
   readonly silent: boolean;
   readonly logLevel: LogLevel;
   readonly logInfoToStdOut: boolean;
-  readonly context: string;
+  readonly context: string | undefined;
   readonly colors: boolean;
   readonly mainFields: string[];
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -50,7 +50,7 @@ export interface ResolverFileSystem {
     path: string,
     callback: (err: Error, linkString: string) => void
   ) => void;
-  readonly readJson: (
+  readonly readJson?: (
     path: string,
     callback: (err: Error, json: {}) => void
   ) => void;
@@ -58,7 +58,7 @@ export interface ResolverFileSystem {
   readonly readdirSync: (path: string) => ReadonlyArray<string>;
   readonly readFileSync: (path: string) => {};
   readonly readlinkSync: (path: string) => string;
-  readonly readJsonSync: (path: string) => {};
+  readonly readJsonSync?: (path: string) => {};
 }
 
 export interface ResolveContext {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,7 @@ import * as TsconfigPaths from "tsconfig-paths";
 import * as path from "path";
 import * as Options from "./options";
 import * as Logger from "./logger";
-import { Stats } from "fs";
+import * as fs from "fs";
 
 export interface ResolverPlugin {
   readonly apply: (resolver: Resolver) => void;
@@ -33,33 +33,7 @@ export type doResolve = (
   callback: Callback
 ) => void;
 
-export interface ResolverFileSystem {
-  readonly stat: (
-    path: string,
-    callback: (err: Error, stats: Stats) => void
-  ) => void;
-  readonly readdir: (
-    path: string,
-    callback: (err: Error, files: ReadonlyArray<string>) => void
-  ) => void;
-  readonly readFile: (
-    path: string,
-    callback: (err: Error, data: {}) => void
-  ) => void;
-  readonly readlink: (
-    path: string,
-    callback: (err: Error, linkString: string) => void
-  ) => void;
-  readonly readJson?: (
-    path: string,
-    callback: (err: Error, json: {}) => void
-  ) => void;
-  readonly statSync: (path: string) => Stats;
-  readonly readdirSync: (path: string) => ReadonlyArray<string>;
-  readonly readFileSync: (path: string) => {};
-  readonly readlinkSync: (path: string) => string;
-  readonly readJsonSync?: (path: string) => {};
-}
+export type ResolverFileSystem = typeof fs;
 
 export interface ResolveContext {
   log?: string;
@@ -387,7 +361,7 @@ function createFileExistAsync(
     path2: string,
     callback2: (err?: Error, exists?: boolean) => void
   ) => {
-    filesystem.stat(path2, (err: Error, stats: Stats) => {
+    filesystem.stat(path2, (err: Error, stats: fs.Stats) => {
       // If error assume file does not exist
       if (err) {
         callback2(undefined, false);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -286,10 +286,10 @@ function createPluginCallback(
 
             // Don't allow other aliasing or raw request
             if (result2 === undefined) {
-              return callback(null, null);
+              return callback(undefined, undefined);
             }
 
-            callback(null, result2);
+            callback(undefined, result2);
           }
         );
       }
@@ -356,7 +356,7 @@ function createPluginLegacy(
             }
 
             // don't allow other aliasing or raw request
-            callback(null, null);
+            callback(undefined, undefined);
           }, callback)
         );
       }


### PR DESCRIPTION
I hope this is acceptable. Re-enabled strict null checks to ensure optional `readJson` types would not break anything, but this meant updating a few existing bits of code.

Fixes #50 

* Re-enable strict null checks (and fix issues)
* Use `typeof fs` for base file system types
* Fallback to `readFile` and `JSON.parse` if `readJson` is unavailable
* Programatic example with custom file system to test `readJson` fallback