### PR TITLE
Copied webpack 5 types into `plugins.temp.types.ts`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "@types/node": "^14.14.33",
+    "@types/node": "^14.14.34",
     "husky": "^5.1.3",
     "jest": "^26.6.3",
     "jest-mock-process": "^1.4.0",
@@ -22,11 +22,11 @@
     "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.3",
-    "ts-loader": "^8.0.17",
+    "ts-loader": "^8.0.18",
     "tslint": "^5.20.1",
     "tslint-immutable": "^6.0.1",
     "typescript": "^4.2.3",
-    "webpack": "^5.24.4",
+    "webpack": "^5.25.1",
     "webpack-cli": "^4.5.0"
   },
   "scripts": {

--- a/src/__tests__/plugins.spec.ts
+++ b/src/__tests__/plugins.spec.ts
@@ -7,7 +7,7 @@ describe(`TsconfigPathsPlugin`, () => {
   const SETTINGS: Configuration = {
     mode: "development",
     context: path.resolve(__dirname, "src"),
-    entry: `../../../example/src/index.ts`,
+    entry: `${__dirname}/../../example/src/index.ts`,
     output: {
       path: path.join(__dirname, "../../temp"),
       filename: "bundle.js",
@@ -38,7 +38,7 @@ describe(`TsconfigPathsPlugin`, () => {
     });
     expect(testPlugin).toBeInstanceOf(TsconfigPathsPlugin);
 
-    const testSettings: webpack.Configuration = {
+    const testSettings: Configuration = {
       ...SETTINGS,
       resolve: {
         extensions: [".ts", ".tsx", ".js"],
@@ -57,6 +57,63 @@ describe(`TsconfigPathsPlugin`, () => {
       const details = stats?.toJson();
       expect(details?.errorsCount).toEqual(0);
       // TODO There should probably be a test that verifies the stats match what is expected
+      done();
+    });
+  });
+
+  it(`Test to ensure Apply exists and is working`, async (done) => {
+    const webpackSettings: Configuration = {
+      entry: `${__dirname}/../../example/src/index.ts`,
+      target: "web",
+      output: {
+        path: path.join(__dirname, "../../temp"),
+        filename: "[name].js",
+      },
+      mode: "development",
+      resolve: {
+        extensions: [
+          ".ts",
+          ".tsx",
+          ".js",
+          ".jsx",
+          "ttf",
+          "eot",
+          "otf",
+          "svg",
+          "png",
+          "woff",
+          "woff2",
+        ],
+        plugins: [
+          new TsconfigPathsPlugin({
+            configFile: `${__dirname}/../../example/tsconfig.json`,
+          }),
+        ],
+      },
+      module: {
+        rules: [],
+      },
+    };
+    // Build compiler
+    const compiler = webpack(webpackSettings);
+    const pluginInstance = compiler?.options?.resolve?.plugins?.find(
+      (plugin) => plugin instanceof TsconfigPathsPlugin
+    );
+    if (!pluginInstance) {
+      return done(`TsconfigPathsPlugin not loaded in webpack settings`);
+    }
+    expect(pluginInstance instanceof TsconfigPathsPlugin).toBeTruthy();
+    expect((pluginInstance as TsconfigPathsPlugin).apply).toBeDefined();
+
+    // Run compiler
+    compiler.run((err, stats) => {
+      if (err) {
+        done(err);
+        return;
+      }
+      expect(stats).toBeDefined();
+      const details = stats?.toJson();
+      expect(details?.errorsCount).toEqual(0);
       done();
     });
   });

--- a/src/plugin.temp.types.ts
+++ b/src/plugin.temp.types.ts
@@ -1,0 +1,457 @@
+/* tslint:disable: no-any */
+/*
+ * This file was copied from Webpack : "version": "5.25.1",
+ * It is copied here as necessary types are not exported from webpack yet
+ * https://github.com/webpack/webpack/pull/12875
+ * TODO: Remove this once Resolver and ResolvePluginInstance are exported
+ */
+
+import { AsyncSeriesBailHook, AsyncSeriesHook, SyncHook } from "tapable";
+
+export interface ResolvePluginInstance {
+  apply: (resolver: Resolver) => void;
+}
+
+declare interface AliasOption {
+  alias: string | false | string[];
+  name: string;
+  onlyModule?: boolean;
+}
+type AliasOptionNewRequest = string | false | string[];
+declare interface AliasOptions {
+  [index: string]: AliasOptionNewRequest;
+}
+declare interface BaseResolveRequest {
+  path: string | false;
+  descriptionFilePath?: string;
+  descriptionFileRoot?: string;
+  descriptionFileData?: object;
+  relativePath?: string;
+  ignoreSymlinks?: boolean;
+  fullySpecified?: boolean;
+}
+declare class CachedInputFileSystem {
+  constructor(fileSystem?: any, duration?: any);
+  fileSystem: any;
+  lstat?: {
+    (arg0: string, arg1: FileSystemCallback<FileSystemStats>): void;
+    (
+      arg0: string,
+      arg1: object,
+      arg2: FileSystemCallback<string | Buffer>
+    ): void;
+  };
+  lstatSync?: (arg0: string, arg1?: object) => FileSystemStats;
+  stat: {
+    (arg0: string, arg1: FileSystemCallback<FileSystemStats>): void;
+    (
+      arg0: string,
+      arg1: object,
+      arg2: FileSystemCallback<string | Buffer>
+    ): void;
+  };
+  statSync: (arg0: string, arg1?: object) => FileSystemStats;
+  readdir: {
+    (
+      arg0: string,
+      arg1: FileSystemCallback<(string | Buffer)[] | FileSystemDirent[]>
+    ): void;
+    (
+      arg0: string,
+      arg1: object,
+      arg2: FileSystemCallback<(string | Buffer)[] | FileSystemDirent[]>
+    ): void;
+  };
+  readdirSync: (
+    arg0: string,
+    arg1?: object
+  ) => (string | Buffer)[] | FileSystemDirent[];
+  readFile: {
+    (arg0: string, arg1: FileSystemCallback<string | Buffer>): void;
+    (
+      arg0: string,
+      arg1: object,
+      arg2: FileSystemCallback<string | Buffer>
+    ): void;
+  };
+  readFileSync: (arg0: string, arg1?: object) => string | Buffer;
+  readJson?: {
+    (arg0: string, arg1: FileSystemCallback<object>): void;
+    (arg0: string, arg1: object, arg2: FileSystemCallback<object>): void;
+  };
+  readJsonSync?: (arg0: string, arg1?: object) => object;
+  readlink: {
+    (arg0: string, arg1: FileSystemCallback<string | Buffer>): void;
+    (
+      arg0: string,
+      arg1: object,
+      arg2: FileSystemCallback<string | Buffer>
+    ): void;
+  };
+  readlinkSync: (arg0: string, arg1?: object) => string | Buffer;
+  purge(what?: any): void;
+}
+declare class CloneBasenamePlugin {
+  constructor(source?: any, target?: any);
+  source: any;
+  target: any;
+  apply(resolver: Resolver): void;
+}
+export declare interface FileSystem {
+  readFile: {
+    (arg0: string, arg1: FileSystemCallback<string | Buffer>): void;
+    (
+      arg0: string,
+      arg1: object,
+      arg2: FileSystemCallback<string | Buffer>
+    ): void;
+  };
+  readdir: {
+    (
+      arg0: string,
+      arg1: FileSystemCallback<(string | Buffer)[] | FileSystemDirent[]>
+    ): void;
+    (
+      arg0: string,
+      arg1: object,
+      arg2: FileSystemCallback<(string | Buffer)[] | FileSystemDirent[]>
+    ): void;
+  };
+  readJson?: {
+    (arg0: string, arg1: FileSystemCallback<object>): void;
+    (arg0: string, arg1: object, arg2: FileSystemCallback<object>): void;
+  };
+  readlink: {
+    (arg0: string, arg1: FileSystemCallback<string | Buffer>): void;
+    (
+      arg0: string,
+      arg1: object,
+      arg2: FileSystemCallback<string | Buffer>
+    ): void;
+  };
+  lstat?: {
+    (arg0: string, arg1: FileSystemCallback<FileSystemStats>): void;
+    (
+      arg0: string,
+      arg1: object,
+      arg2: FileSystemCallback<string | Buffer>
+    ): void;
+  };
+  stat: {
+    (arg0: string, arg1: FileSystemCallback<FileSystemStats>): void;
+    (
+      arg0: string,
+      arg1: object,
+      arg2: FileSystemCallback<string | Buffer>
+    ): void;
+  };
+}
+declare interface FileSystemCallback<T> {
+  (err?: null | (PossibleFileSystemError & Error), result?: T): any;
+}
+declare interface FileSystemDirent {
+  name: string | Buffer;
+  isDirectory: () => boolean;
+  isFile: () => boolean;
+}
+declare interface FileSystemStats {
+  isDirectory: () => boolean;
+  isFile: () => boolean;
+}
+declare class LogInfoPlugin {
+  constructor(source?: any);
+  source: any;
+  apply(resolver: Resolver): void;
+}
+declare interface ParsedIdentifier {
+  request: string;
+  query: string;
+  fragment: string;
+  directory: boolean;
+  module: boolean;
+  file: boolean;
+  internal: boolean;
+}
+type Plugin =
+  | { apply: (arg0: Resolver) => void }
+  | ((this: Resolver, arg1: Resolver) => void);
+declare interface PnpApiImpl {
+  resolveToUnqualified: (arg0: string, arg1: string, arg2: object) => string;
+}
+declare interface PossibleFileSystemError {
+  code?: string;
+  errno?: number;
+  path?: string;
+  syscall?: string;
+}
+
+/**
+ * Resolve context
+ */
+export declare interface ResolveContext {
+  contextDependencies?: WriteOnlySet<string>;
+
+  /**
+   * files that was found on file system
+   */
+  fileDependencies?: WriteOnlySet<string>;
+
+  /**
+   * dependencies that was not found on file system
+   */
+  missingDependencies?: WriteOnlySet<string>;
+
+  /**
+   * set of hooks' calls. For instance, `resolve → parsedResolve → describedResolve`,
+   */
+  stack?: Set<string>;
+
+  /**
+   * log function
+   */
+  log?: (arg0: string) => void;
+}
+declare interface ResolveOptions {
+  alias: AliasOption[];
+  fallback: AliasOption[];
+  aliasFields: Set<string | string[]>;
+  cachePredicate: (arg0: ResolveRequest) => boolean;
+  cacheWithContext: boolean;
+
+  /**
+   * A list of exports field condition names.
+   */
+  conditionNames: Set<string>;
+  descriptionFiles: string[];
+  enforceExtension: boolean;
+  exportsFields: Set<string | string[]>;
+  importsFields: Set<string | string[]>;
+  extensions: Set<string>;
+  fileSystem: FileSystem;
+  unsafeCache: false | object;
+  symlinks: boolean;
+  resolver?: Resolver;
+  modules: (string | string[])[];
+  mainFields: { name: string[]; forceRelative: boolean }[];
+  mainFiles: Set<string>;
+  plugins: Plugin[];
+  pnpApi: null | PnpApiImpl;
+  roots: Set<string>;
+  fullySpecified: boolean;
+  resolveToContext: boolean;
+  restrictions: Set<string | RegExp>;
+  preferRelative: boolean;
+  preferAbsolute: boolean;
+}
+export type ResolveRequest = BaseResolveRequest & Partial<ParsedIdentifier>;
+export declare abstract class Resolver {
+  fileSystem: FileSystem;
+  options: ResolveOptions;
+  hooks: {
+    resolveStep: SyncHook<
+      [
+        AsyncSeriesBailHook<
+          [ResolveRequest, ResolveContext],
+          null | ResolveRequest
+        >,
+        ResolveRequest
+      ]
+    >;
+    noResolve: SyncHook<[ResolveRequest, Error]>;
+    resolve: AsyncSeriesBailHook<
+      [ResolveRequest, ResolveContext],
+      null | ResolveRequest
+    >;
+    result: AsyncSeriesHook<[ResolveRequest, ResolveContext]>;
+  };
+  ensureHook(
+    name:
+      | string
+      | AsyncSeriesBailHook<
+          [ResolveRequest, ResolveContext],
+          null | ResolveRequest
+        >
+  ): AsyncSeriesBailHook<
+    [ResolveRequest, ResolveContext],
+    null | ResolveRequest
+  >;
+  getHook(
+    name:
+      | string
+      | AsyncSeriesBailHook<
+          [ResolveRequest, ResolveContext],
+          null | ResolveRequest
+        >
+  ): AsyncSeriesBailHook<
+    [ResolveRequest, ResolveContext],
+    null | ResolveRequest
+  >;
+  resolveSync(context: object, path: string, request: string): string | false;
+  resolve(
+    context: object,
+    path: string,
+    request: string,
+    resolveContext: ResolveContext,
+    callback: (
+      arg0: null | Error,
+      arg1?: string | false,
+      arg2?: ResolveRequest
+    ) => void
+  ): void;
+  doResolve(
+    hook?: any,
+    request?: any,
+    message?: any,
+    resolveContext?: any,
+    callback?: any
+  ): any;
+  parse(identifier: string): ParsedIdentifier;
+  isModule(path?: any): boolean;
+  isPrivate(path?: any): boolean;
+  isDirectory(path: string): boolean;
+  join(path?: any, request?: any): string;
+  normalize(path?: any): string;
+}
+declare interface UserResolveOptions {
+  /**
+   * A list of module alias configurations or an object which maps key to value
+   */
+  alias?: AliasOptions | AliasOption[];
+
+  /**
+   * A list of module alias configurations or an object which maps key to value, applied only after modules option
+   */
+  fallback?: AliasOptions | AliasOption[];
+
+  /**
+   * A list of alias fields in description files
+   */
+  aliasFields?: (string | string[])[];
+
+  /**
+   * A function which decides whether a request should be cached or not. An object is passed with at least `path` and `request` properties.
+   */
+  cachePredicate?: (arg0: ResolveRequest) => boolean;
+
+  /**
+   * Whether or not the unsafeCache should include request context as part of the cache key.
+   */
+  cacheWithContext?: boolean;
+
+  /**
+   * A list of description files to read from
+   */
+  descriptionFiles?: string[];
+
+  /**
+   * A list of exports field condition names.
+   */
+  conditionNames?: string[];
+
+  /**
+   * Enforce that a extension from extensions must be used
+   */
+  enforceExtension?: boolean;
+
+  /**
+   * A list of exports fields in description files
+   */
+  exportsFields?: (string | string[])[];
+
+  /**
+   * A list of imports fields in description files
+   */
+  importsFields?: (string | string[])[];
+
+  /**
+   * A list of extensions which should be tried for files
+   */
+  extensions?: string[];
+
+  /**
+   * The file system which should be used
+   */
+  fileSystem: FileSystem;
+
+  /**
+   * Use this cache object to unsafely cache the successful requests
+   */
+  unsafeCache?: boolean | object;
+
+  /**
+   * Resolve symlinks to their symlinked location
+   */
+  symlinks?: boolean;
+
+  /**
+   * A prepared Resolver to which the plugins are attached
+   */
+  resolver?: Resolver;
+
+  /**
+   * A list of directories to resolve modules from, can be absolute path or folder name
+   */
+  modules?: string | string[];
+
+  /**
+   * A list of main fields in description files
+   */
+  mainFields?: (
+    | string
+    | string[]
+    | { name: string | string[]; forceRelative: boolean }
+  )[];
+
+  /**
+   * A list of main files in directories
+   */
+  mainFiles?: string[];
+
+  /**
+   * A list of additional resolve plugins which should be applied
+   */
+  plugins?: Plugin[];
+
+  /**
+   * A PnP API that should be used - null is "never", undefined is "auto"
+   */
+  pnpApi?: null | PnpApiImpl;
+
+  /**
+   * A list of root paths
+   */
+  roots?: string[];
+
+  /**
+   * The request is already fully specified and no extensions or directories are resolved for it
+   */
+  fullySpecified?: boolean;
+
+  /**
+   * Resolve to a context instead of a file
+   */
+  resolveToContext?: boolean;
+
+  /**
+   * A list of resolve restrictions
+   */
+  restrictions?: (string | RegExp)[];
+
+  /**
+   * Use only the sync constiants of the file system calls
+   */
+  useSyncFileSystemCalls?: boolean;
+
+  /**
+   * Prefer to resolve module requests as relative requests before falling back to modules
+   */
+  preferRelative?: boolean;
+
+  /**
+   * Prefer to resolve server-relative urls as absolute paths before falling back to resolve in roots
+   */
+  preferAbsolute?: boolean;
+}
+declare interface WriteOnlySet<T> {
+  add: (T?: any) => void;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -603,10 +603,15 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/node@*", "@types/node@^14.14.33":
+"@types/node@*":
   version "14.14.33"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.33.tgz#9e4f8c64345522e4e8ce77b334a8aaa64e2b6c78"
   integrity sha512-oJqcTrgPUF29oUP8AsUqbXGJNuPutsetaa9kTQAQce5Lx5dTYWV02ScBiT/k1BX/Z7pKeqedmvp39Wu4zR7N7g==
+
+"@types/node@^14.14.34":
+  version "14.14.34"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.34.tgz#07935194fc049069a1c56c0c274265abeddf88da"
+  integrity sha512-dBPaxocOK6UVyvhbnpFIj2W+S+1cBTkHQbFQfeeJhoKFbzYcVUGHvddeWPSucKATb3F0+pgDq0i6ghEaZjsugA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -4172,10 +4177,10 @@ ts-jest@^26.5.3:
     semver "7.x"
     yargs-parser "20.x"
 
-ts-loader@^8.0.17:
-  version "8.0.17"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.17.tgz#98f2ccff9130074f4079fd89b946b4c637b1f2fc"
-  integrity sha512-OeVfSshx6ot/TCxRwpBHQ/4lRzfgyTkvi7ghDVrLXOHzTbSK413ROgu/xNqM72i3AFeAIJgQy78FwSMKmOW68w==
+ts-loader@^8.0.18:
+  version "8.0.18"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.18.tgz#b2385cbe81c34ad9f997915129cdde3ad92a61ea"
+  integrity sha512-hRZzkydPX30XkLaQwJTDcWDoxZHK6IrEMDQpNd7tgcakFruFkeUp/aY+9hBb7BUGb+ZWKI0jiOGMo0MckwzdDQ==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^4.0.0"
@@ -4450,10 +4455,10 @@ webpack-sources@^2.1.1:
     source-list-map "^2.0.1"
     source-map "^0.6.1"
 
-webpack@^5.24.4:
-  version "5.24.4"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.24.4.tgz#37d8cf95841dd23c809ea02931294b3455d74a59"
-  integrity sha512-RXOdxF9hFFFhg47BryCgyFrEyyu7Y/75/uiI2DoUiTMqysK+WczVSTppvkR47oZcmI/DPaXCiCiaXBP8QjkNpA==
+webpack@^5.25.1:
+  version "5.25.1"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.25.1.tgz#d3564440ed2569253fa45864405a313916bef6f6"
+  integrity sha512-dzFTJwehoLZkeHUkvMSwAgVdGL+PerfX0mke9tOWjJs4OzFctkxCqD8Zj5J387jLkC4gNqSin0/EurhH28boCg==
   dependencies:
     "@types/eslint-scope" "^3.7.0"
     "@types/estree" "^0.0.46"


### PR DESCRIPTION
This typing pass makes pretty much all the typings in the code run as expected. 
To do this, I copied over the webpack types and shoved them in a temp typings file for use.

Not the greatest, but it is way more typesafe.

It also seemed that the types were wrong in a couple of places. The code worked fine, so looking into it there were callbacks with an Object instead of the typed String. 
