### PR TITLE
Fix incorrect resolution with relative imports on project dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsconfig-paths-webpack-plugin",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "Load modules according to tsconfig paths in webpack.",
   "main": "lib/index.js",
   "types": "lib/index",

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -245,8 +245,8 @@ function createPluginCallback(
 
     if (
       !innerRequest ||
-      innerRequest.startsWith(".") ||
-      innerRequest.startsWith("..")
+      request.request.startsWith(".") ||
+      request.request.startsWith("..")
     ) {
       return callback();
     }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -245,8 +245,8 @@ function createPluginCallback(
 
     if (
       !innerRequest ||
-      request.request.startsWith(".") ||
-      request.request.startsWith("..")
+      request?.request?.startsWith(".") ||
+      request?.request?.startsWith("..")
     ) {
       return callback();
     }


### PR DESCRIPTION
I ran across #83 on my project, where I have a dependency which has a relative import to a file that happens to have the same name as one of my roots.

I think the issue is on this line: It's checking for the resolved `innerRequest`, which strips the relative prefix for dependencies. I think that what it should be is if the original non-resolved request (`request.request`).

With this change I no longer have this issue, but I'm not sure this is OK