### PR TITLE
Pass through `ResolveTypes` from Webpack

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -1,15 +1,17 @@
+import { ResolveOptions } from "webpack";
+
 export type LogLevel = "INFO" | "WARN" | "ERROR";
 
 export interface Options {
   readonly configFile: string;
-  readonly extensions: ReadonlyArray<string>;
+  readonly extensions: ResolveOptions["extensions"];
   readonly baseUrl: string | undefined;
   readonly silent: boolean;
   readonly logLevel: LogLevel;
   readonly logInfoToStdOut: boolean;
   readonly context: string | undefined;
   readonly colors: boolean;
-  readonly mainFields: string[];
+  readonly mainFields: ResolveOptions["mainFields"];
 }
 
 type ValidOptions = keyof Options;


### PR DESCRIPTION
Resolves #88.

Note that I'm unsure why `extensions` was originally defined as `ReadonlyArray`, but I am pretty sure the intent is to accept the exact types coming from Webpack. So there might still be an internal change needed to account for this change in type.