### PR TITLE
Revert "Pass through `ResolveTypes` from Webpack"

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -1,17 +1,15 @@
-import { ResolveOptions } from "webpack";
-
 export type LogLevel = "INFO" | "WARN" | "ERROR";
 
 export interface Options {
   readonly configFile: string;
-  readonly extensions: ResolveOptions["extensions"];
+  readonly extensions: ReadonlyArray<string>;
   readonly baseUrl: string | undefined;
   readonly silent: boolean;
   readonly logLevel: LogLevel;
   readonly logInfoToStdOut: boolean;
   readonly context: string | undefined;
   readonly colors: boolean;
-  readonly mainFields: ResolveOptions["mainFields"];
+  readonly mainFields: string[];
 }
 
 type ValidOptions = keyof Options;


### PR DESCRIPTION
Reverts dividab/tsconfig-paths-webpack-plugin#93

This change broke a lot of other stuff so I have to revert it for now.
I'll try to put some time into getting CI to work for PR and then we can try again.