### PR TITLE
Pass through `ResolveTypes` from Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "enhanced-resolve": "^5.7.0",
-    "tsconfig-paths": "^4.0.0"
+    "tsconfig-paths": "^4.1.0"
   },
   "devDependencies": {
     "@types/jest": "^27.0.3",

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,15 +1,17 @@
+import { ResolveOptions } from "webpack";
+
 export type LogLevel = "INFO" | "WARN" | "ERROR";
 
 export interface Options {
   readonly configFile: string;
-  readonly extensions: ReadonlyArray<string>;
+  readonly extensions: ResolveOptions["extensions"];
   readonly baseUrl: string | undefined;
   readonly silent: boolean;
   readonly logLevel: LogLevel;
   readonly logInfoToStdOut: boolean;
   readonly context: string | undefined;
   readonly colors: boolean;
-  readonly mainFields: string[];
+  readonly mainFields: ResolveOptions["mainFields"];
 }
 
 type ValidOptions = keyof Options;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as Options from "./options";
 import * as Logger from "./logger";
 import * as fs from "fs";
-import { ResolvePluginInstance, Resolver } from "webpack";
+import { ResolveOptions, ResolvePluginInstance, Resolver } from "webpack";
 import { ResolveRequest, ResolveContext } from "enhanced-resolve";
 
 type FileSystem = Resolver["fileSystem"];
@@ -127,7 +127,7 @@ export class TsconfigPathsPlugin implements ResolvePluginInstance {
   log: Logger.Logger;
   baseUrl: string | undefined;
   absoluteBaseUrl: string;
-  extensions: ReadonlyArray<string>;
+  extensions: ResolveOptions["extensions"];
 
   matchPath: TsconfigPaths.MatchPathAsync;
 
@@ -160,7 +160,7 @@ export class TsconfigPathsPlugin implements ResolvePluginInstance {
       this.matchPath = TsconfigPaths.createMatchPathAsync(
         this.absoluteBaseUrl,
         loadResult.paths,
-        options.mainFields
+        options.mainFields as string[] | undefined
       );
     }
   }
@@ -231,7 +231,7 @@ function createPluginCallback(
   resolver: Resolver,
   absoluteBaseUrl: string,
   hook: Tapable,
-  extensions: ReadonlyArray<string>
+  extensions: ResolveOptions["extensions"]
 ): TapAsyncCallback {
   const fileExistAsync = createFileExistAsync(resolver.fileSystem);
   const readJsonAsync = createReadJsonAsync(resolver.fileSystem);
@@ -306,7 +306,7 @@ function createPluginLegacy(
   resolver: LegacyResolver,
   absoluteBaseUrl: string,
   target: string,
-  extensions: ReadonlyArray<string>
+  extensions: ResolveOptions["extensions"]
 ): ResolverCallbackLegacy {
   const fileExistAsync = createFileExistAsync(resolver.fileSystem);
   const readJsonAsync = createReadJsonAsync(resolver.fileSystem);

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -160,7 +160,7 @@ export class TsconfigPathsPlugin implements ResolvePluginInstance {
       this.matchPath = TsconfigPaths.createMatchPathAsync(
         this.absoluteBaseUrl,
         loadResult.paths,
-        options.mainFields as string[] | undefined
+        options.mainFields
       );
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4471,10 +4471,10 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tsconfig-paths@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.0.0.tgz#1082f5d99fd127b72397eef4809e4dd06d229b64"
-  integrity sha512-SLBg2GBKlR6bVtMgJJlud/o3waplKtL7skmLkExomIiaAtLGtVsoXIqP3SYdjbcH9lq/KVv7pMZeCBpLYOit6Q==
+tsconfig-paths@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz#f8ef7d467f08ae3a695335bf1ece088c5538d2c1"
+  integrity sha512-AHx4Euop/dXFC+Vx589alFba8QItjF+8hf8LtmuiCwHyI4rHXQtOOENaM8kvYf5fR0dRChy3wzWIZ9WbB7FWow==
   dependencies:
     json5 "^2.2.1"
     minimist "^1.2.6"


### PR DESCRIPTION
Resolves #88.

Unlike #93, this time I made the necessary internal changes.

~~Note there is now one type assertion due to a bad upstream type in `tsconfig-paths`. I filed https://github.com/dividab/tsconfig-paths/issues/217 to resolve, but for now the assertion should be fine, since it's only a type change - no functional changes.~~