### PR TITLE
Update tsconfig file name in `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -9,4 +9,4 @@ thumbs.db
 .editorconfig
 .gitignore
 .npmignore
-base-tsconfig.json
+tsconfig.json


### PR DESCRIPTION
I'm assuming the file name was changed at some point from `base-tsconfig.json` to just `tsconfig.json` and was never changed in `.npmignore`.

Intellisense in vscode keeps detecting it in `node_modules` and complaining that it can't locate the project's source code.