### PR TITLE
Remove warning on missing baseUrl, which tsconfig-paths ^4.0.0 doesn't require anymore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/dividab/tsconfig-paths-webpack-plugin/compare/v4.0.1...master)
 
-- Remove warning on missing baseUrl, which tsconfig-paths ^4.0.0 doesn't require anymore.
+- Remove warning on missing baseUrl, which tsconfig-paths ^4.0.0 doesn't require anymore [#105](https://github.com/dividab/tsconfig-paths-webpack-plugin/pull/105).
 
 ## [4.0.1](https://github.com/dividab/tsconfig-paths-webpack-plugin/compare/v4.0.0...v4.0.1) - 2023-03-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased](https://github.com/dividab/tsconfig-paths-webpack-plugin/compare/v4.0.1...master)
 
+- Remove warning on missing baseUrl, which tsconfig-paths ^4.0.0 doesn't require anymore.
+
 ## [4.0.1](https://github.com/dividab/tsconfig-paths-webpack-plugin/compare/v4.0.0...v4.0.1) - 2023-03-09
 
 - Update tsconfig-paths [#103](https://github.com/dividab/tsconfig-paths-webpack-plugin/pull/103). Thanks to [@rippedspine](https://github.com/rippedspine) for this PR!

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -173,16 +173,6 @@ export class TsconfigPathsPlugin implements ResolvePluginInstance {
       return;
     }
 
-    const { baseUrl } = this;
-
-    if (!baseUrl) {
-      // Nothing to do if there is no baseUrl
-      this.log.logWarning(
-        "tsconfig-paths-webpack-plugin: Found no baseUrl in tsconfig.json, not applying tsconfig-paths-webpack-plugin"
-      );
-      return;
-    }
-
     // The file system only exists when the plugin is in the resolve context. This means it's also properly placed in the resolve.plugins array.
     // If not, we should warn the user that this plugin should be placed in resolve.plugins and not the plugins array of the root config for example.
     // This should hopefully prevent issues like: https://github.com/dividab/tsconfig-paths-webpack-plugin/issues/9


### PR DESCRIPTION
### description

- removes the check & associated warning on a missing baseUrl in tsconfig.json
- ensures plugin loading & executing commences even in the absence of a baseUrl

### motivation & context

fixes #99 (& fixes #59 - which seems a duplicated of the former)

... which follows from [tsconfig-paths PR #208](https://github.com/dividab/tsconfig-paths/pull/208) which makes tsconfig-paths tolerate empty/ non-existing baseUrl's, 
... which is consistent with [TypeScript >=4.1 behavior](https://www.typescriptlang.org/tsconfig#baseUrl)
... on which frameworks (like next.js) and newer projects are starting to rely

### how this was tested

- [ ] green ci ( ⏳ )
- [x] manual validation with a local install of tsconfig-paths-webpack-plugin
