### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "tsconfig-paths-webpack-plugin",
   "version": "4.2.0",
+  "homepage": "https://github.com/jonaskello/tsconfig-paths-webpack-plugin",
+  "bugs": {
+    "url": "https://github.com/jonaskello/tsconfig-paths-webpack-plugin/issues"
+  },
   "description": "Load modules according to tsconfig paths in webpack.",
   "main": "lib/index.js",
   "types": "lib/index",


### PR DESCRIPTION
Adds missing `bugs, homepage` metadata to `package.json`.